### PR TITLE
docs: 更新安装文档中的下载链接至官网

### DIFF
--- a/courses/install/step1.md
+++ b/courses/install/step1.md
@@ -16,17 +16,14 @@
 
 3.  **下载 KWDB 安装包**
 
-    现在，我们从官方仓库下载最新的 KWDB 安装包。
+    现在，我们官网下载最新的 KWDB 安装包。
 
-    `wget https://github.com/KWDB/KWDB/releases/download/V${KW_VERSION}/KWDB-${KW_VERSION}-ubuntu20.04-$(arch)-debs.tar.gz`{{exec}}
-
-    > 如果当前网络环境无法连接 Github 仓库，您可以从 Gitee 镜像下载安装包。
-    > `wget https://gitee.com/kwdb/kwdb/releases/download/V${KW_VERSION}/KWDB-${KW_VERSION}-ubuntu20.04-$(arch)-debs.tar.gz`{{exec}}
+    `wget https://kwdb.tech/download/KWDB-${KW_VERSION}-ubuntu20.04-$(arch)`{{exec}}
 
 4.  **解压安装包**
 
-    下载完成后，解压刚刚下载的 `tar.gz` 文件。
+    下载完成后，解压刚刚下载的文件。
 
-    `tar -xzvf KWDB-${KW_VERSION}-ubuntu20.04-$(arch)-debs.tar.gz`{{exec}}
+    `tar -xzvf KWDB-${KW_VERSION}-ubuntu20.04-$(arch)`{{exec}}
 
 至此，准备工作已完成。在下一步中，我们将开始修改配置文件，为正式安装做准备。

--- a/courses/upgrade-3.0-to-3.1/step3.md
+++ b/courses/upgrade-3.0-to-3.1/step3.md
@@ -6,12 +6,9 @@
 
    `cd ~`{{exec}}
 
-   `wget https://github.com/KWDB/KWDB/releases/download/V${NEW_KW_VERSION}/KWDB-${NEW_KW_VERSION}-ubuntu20.04-$(arch)-debs.tar.gz`{{exec}}
+   `wget https://kwdb.tech/download/KWDB-${NEW_KW_VERSION}-ubuntu20.04-$(arch)`{{exec}}
 
-   > 如果当前网络环境无法访问 GitHub，可以改用 Gitee 镜像：
-   > `wget https://gitee.com/kwdb/kwdb/releases/download/V${NEW_KW_VERSION}/KWDB-${NEW_KW_VERSION}-ubuntu20.04-$(arch)-debs.tar.gz`{{exec}}
-
-   `tar -xzvf KWDB-${NEW_KW_VERSION}-ubuntu20.04-$(arch)-debs.tar.gz`{{exec}}
+   `tar -xzvf KWDB-${NEW_KW_VERSION}-ubuntu20.04-$(arch)`{{exec}}
 
    `mv kwdb_install kwdb_install_${NEW_KW_VERSION}`{{exec}}
 


### PR DESCRIPTION
将 GitHub/Gitee 的发布页下载链接统一替换为官网下载链接，
并移除相关的镜像说明，简化用户操作步骤。