### PR TITLE
fix(api): 修复课程启动时卷绑定逻辑，支持文件注入与挂载

### DIFF
--- a/internal/api/handlers_course_runtime.go
+++ b/internal/api/handlers_course_runtime.go
@@ -193,7 +193,7 @@ func (h *Handler) startCourse(c *gin.Context) {
 
 	if len(course.Backend.Volumes) > 0 {
 		filesToInject = make(map[string][]byte)
-		
+
 		baseDir := h.cfg.Course.Dir
 		if !filepath.IsAbs(baseDir) {
 			if absBase, err := filepath.Abs(baseDir); err == nil {
@@ -214,7 +214,7 @@ func (h *Handler) startCourse(c *gin.Context) {
 				h.logger.Warn("[startCourse] 无效的卷绑定: %s，期望格式 source:container[:opts]", b)
 				continue
 			}
-			
+
 			sourcePath := strings.TrimSpace(parts[0])
 			containerPath := strings.TrimSpace(parts[1])
 			if len(parts) == 3 && strings.TrimSpace(parts[2]) != "" {
@@ -586,3 +586,4 @@ func (h *Handler) resumeCourse(c *gin.Context) {
 		"containerId": target.ID,
 	})
 }
+

--- a/internal/api/handlers_course_runtime.go
+++ b/internal/api/handlers_course_runtime.go
@@ -191,37 +191,9 @@ func (h *Handler) startCourse(c *gin.Context) {
 	volumes := make(map[string]string)
 	var filesToInject map[string][]byte
 
-	if len(course.Backend.Volumes) > 0 && h.cfg.Course.DockerDeploy {
+	if len(course.Backend.Volumes) > 0 {
 		filesToInject = make(map[string][]byte)
-		for _, bind := range course.Backend.Volumes {
-			b := strings.TrimSpace(bind)
-			if b == "" {
-				continue
-			}
-			parts := strings.SplitN(b, ":", 3)
-			if len(parts) < 2 {
-				h.logger.Warn("[startCourse] 无效的卷绑定: %s，期望格式 source:container[:opts]", b)
-				continue
-			}
-			sourcePath := strings.TrimSpace(parts[0])
-			containerPath := strings.TrimSpace(parts[1])
-
-			if strings.HasPrefix(sourcePath, "./") {
-				sourcePath = sourcePath[2:]
-			}
-
-			content, err := h.courseService.ReadCourseFile(course.ID, sourcePath)
-			if err != nil {
-				h.logger.Error("[startCourse] Docker模式读取课程文件失败: %s/%s: %v", course.ID, sourcePath, err)
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": fmt.Sprintf("读取课程文件失败: %s: %v", sourcePath, err),
-				})
-				return
-			}
-			filesToInject[containerPath] = content
-			h.logger.Debug("[startCourse] Docker模式准备注入文件: %s -> %s (%d bytes)", sourcePath, containerPath, len(content))
-		}
-	} else if len(course.Backend.Volumes) > 0 {
+		
 		baseDir := h.cfg.Course.Dir
 		if !filepath.IsAbs(baseDir) {
 			if absBase, err := filepath.Abs(baseDir); err == nil {
@@ -239,41 +211,67 @@ func (h *Handler) startCourse(c *gin.Context) {
 			}
 			parts := strings.SplitN(b, ":", 3)
 			if len(parts) < 2 {
-				h.logger.Warn("[startCourse] 无效的卷绑定: %s，期望格式 host:container[:opts]", b)
+				h.logger.Warn("[startCourse] 无效的卷绑定: %s，期望格式 source:container[:opts]", b)
 				continue
 			}
-
-			hostPath := strings.TrimSpace(parts[0])
+			
+			sourcePath := strings.TrimSpace(parts[0])
 			containerPath := strings.TrimSpace(parts[1])
 			if len(parts) == 3 && strings.TrimSpace(parts[2]) != "" {
 				containerPath = containerPath + ":" + strings.TrimSpace(parts[2])
 			}
 
-			if hostPath == "~" || strings.HasPrefix(hostPath, "~/") {
-				if home, herr := os.UserHomeDir(); herr == nil {
-					hostPath = filepath.Join(home, strings.TrimPrefix(hostPath, "~"))
-				} else {
-					h.logger.Warn("[startCourse] 无法解析用户主目录用于卷绑定: %v", herr)
+			isCourseFile := strings.HasPrefix(sourcePath, "./")
+
+			if isCourseFile && (h.cfg.Course.DockerDeploy || h.cfg.Course.UseEmbed) {
+				// 课程文件且在 DockerDeploy 或 UseEmbed 模式下，使用文件注入
+				cleanSourcePath := sourcePath[2:]
+				content, err := h.courseService.ReadCourseFile(course.ID, cleanSourcePath)
+				if err != nil {
+					h.logger.Error("[startCourse] 读取课程文件失败: %s/%s: %v", course.ID, cleanSourcePath, err)
+					c.JSON(http.StatusInternalServerError, gin.H{
+						"error": fmt.Sprintf("读取课程文件失败: %s: %v", cleanSourcePath, err),
+					})
+					return
 				}
-			}
+				// 注入文件不需要 opts，去除可能附带的 :ro 等后缀
+				cleanContainerPath := strings.TrimSpace(parts[1])
+				filesToInject[cleanContainerPath] = content
+				h.logger.Debug("[startCourse] 准备注入文件: %s -> %s (%d bytes)", cleanSourcePath, cleanContainerPath, len(content))
+			} else {
+				// 非课程文件，或者在纯本地模式下，使用 bind mount
+				if h.cfg.Course.DockerDeploy {
+					h.logger.Warn("[startCourse] DockerDeploy 模式下不支持主机绝对路径挂载: %s", sourcePath)
+					continue
+				}
 
-			if !filepath.IsAbs(hostPath) {
-				hostPath = filepath.Join(courseBase, hostPath)
-			}
-			hostPath = filepath.Clean(hostPath)
-			if absHost, err := filepath.Abs(hostPath); err == nil {
-				hostPath = absHost
-			}
+				hostPath := sourcePath
+				if hostPath == "~" || strings.HasPrefix(hostPath, "~/") {
+					if home, herr := os.UserHomeDir(); herr == nil {
+						hostPath = filepath.Join(home, strings.TrimPrefix(hostPath, "~"))
+					} else {
+						h.logger.Warn("[startCourse] 无法解析用户主目录用于卷绑定: %v", herr)
+					}
+				}
 
-			if _, err := os.Stat(hostPath); os.IsNotExist(err) {
-				h.logger.Warn("[startCourse] 主机路径不存在: %s (课程: %s)", hostPath, course.ID)
-			}
+				if !filepath.IsAbs(hostPath) {
+					hostPath = filepath.Join(courseBase, hostPath)
+				}
+				hostPath = filepath.Clean(hostPath)
+				if absHost, err := filepath.Abs(hostPath); err == nil {
+					hostPath = absHost
+				}
 
-			if !strings.HasPrefix(containerPath, "/") {
-				h.logger.Warn("[startCourse] 容器路径不是绝对路径: %s，建议以/开始", containerPath)
-			}
+				if _, err := os.Stat(hostPath); os.IsNotExist(err) {
+					h.logger.Warn("[startCourse] 主机路径不存在: %s (课程: %s)，Docker 可能会自动创建同名目录", hostPath, course.ID)
+				}
 
-			volumes[hostPath] = containerPath
+				if !strings.HasPrefix(containerPath, "/") {
+					h.logger.Warn("[startCourse] 容器路径不是绝对路径: %s，建议以/开始", containerPath)
+				}
+
+				volumes[hostPath] = containerPath
+			}
 		}
 		h.logger.Debug("[startCourse] 已解析卷绑定(绝对路径): %v", volumes)
 	}

--- a/internal/api/handlers_course_runtime.go
+++ b/internal/api/handlers_course_runtime.go
@@ -586,4 +586,3 @@ func (h *Handler) resumeCourse(c *gin.Context) {
 		"containerId": target.ID,
 	})
 }
-

--- a/internal/api/handlers_course_runtime_test.go
+++ b/internal/api/handlers_course_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing/fstest"
 
 	"github.com/gin-gonic/gin"
+
 	"kwdb-playground/internal/config"
 	"kwdb-playground/internal/course"
 	"kwdb-playground/internal/docker"
@@ -36,10 +37,10 @@ func TestCourseStartInProgressGuard(t *testing.T) {
 
 func TestResolveStartCourseImage(t *testing.T) {
 	tests := []struct {
-		name         string
-		requestImage string
-		backendImage string
-		want         string
+		name		string
+		requestImage	string
+		backendImage	string
+		want		string
 	}{
 		{name: "prefer request image", requestImage: "a:b", backendImage: "x:y", want: "a:b"},
 		{name: "fallback backend image", requestImage: "", backendImage: "x:y", want: "x:y"},
@@ -58,9 +59,9 @@ func TestResolveStartCourseImage(t *testing.T) {
 
 func TestNormalizeCourseCmd(t *testing.T) {
 	tests := []struct {
-		name string
-		in   []string
-		want []string
+		name	string
+		in	[]string
+		want	[]string
 	}{
 		{name: "nil uses default", in: nil, want: []string{"/bin/bash", "-c", "while true; do sleep 3600; done"}},
 		{name: "single token unchanged", in: []string{"postgres"}, want: []string{"postgres"}},
@@ -181,9 +182,9 @@ type mockDockerController struct {
 
 func (m *mockDockerController) CreateContainerWithProgress(ctx context.Context, courseID string, config *docker.ContainerConfig, progressCallback docker.ImagePullProgressCallback) (*docker.ContainerInfo, error) {
 	return &docker.ContainerInfo{
-		ID:       "mock-container-id",
-		DockerID: "mock-docker-id",
-		State:    docker.StateCreating,
+		ID:		"mock-container-id",
+		DockerID:	"mock-docker-id",
+		State:		docker.StateCreating,
 	}, nil
 }
 
@@ -224,18 +225,18 @@ backend:
 
 	cfg := &config.Config{
 		Course: config.CourseConfig{
-			DockerDeploy: true,
-			UseEmbed:     true,
+			DockerDeploy:	true,
+			UseEmbed:	true,
 		},
 	}
 
 	loggerInstance := logger.NewLogger(logger.ERROR)
 	handler := &Handler{
-		courseService:         courseSvc,
-		dockerController:      mockDocker,
-		logger:                loggerInstance,
-		cfg:                   cfg,
-		courseStartInProgress: make(map[string]bool),
+		courseService:		courseSvc,
+		dockerController:	mockDocker,
+		logger:			loggerInstance,
+		cfg:			cfg,
+		courseStartInProgress:	make(map[string]bool),
 	}
 
 	w := httptest.NewRecorder()
@@ -261,3 +262,4 @@ backend:
 		t.Errorf("Expected rdb.tar.gz to be injected with content 'mock-rdb-data', got %q", string(content))
 	}
 }
+

--- a/internal/api/handlers_course_runtime_test.go
+++ b/internal/api/handlers_course_runtime_test.go
@@ -1,12 +1,18 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/gin-gonic/gin"
+	"kwdb-playground/internal/config"
+	"kwdb-playground/internal/course"
+	"kwdb-playground/internal/docker"
+	"kwdb-playground/internal/logger"
 )
 
 func TestCourseStartInProgressGuard(t *testing.T) {
@@ -165,5 +171,93 @@ func TestResolveStartHostPort(t *testing.T) {
 	invalid := 70000
 	if _, err := resolveStartHostPort(&invalid, 26257); err == nil {
 		t.Fatal("resolveStartHostPort invalid port should return error")
+	}
+}
+
+type mockDockerController struct {
+	docker.Controller
+	filesCopied map[string]map[string][]byte
+}
+
+func (m *mockDockerController) CreateContainerWithProgress(ctx context.Context, courseID string, config *docker.ContainerConfig, progressCallback docker.ImagePullProgressCallback) (*docker.ContainerInfo, error) {
+	return &docker.ContainerInfo{
+		ID:       "mock-container-id",
+		DockerID: "mock-docker-id",
+		State:    docker.StateCreating,
+	}, nil
+}
+
+func (m *mockDockerController) CopyFilesToContainer(ctx context.Context, containerID string, files map[string][]byte) error {
+	if m.filesCopied == nil {
+		m.filesCopied = make(map[string]map[string][]byte)
+	}
+	m.filesCopied[containerID] = files
+	return nil
+}
+
+func (m *mockDockerController) StartContainer(ctx context.Context, containerID string) error {
+	return nil
+}
+
+func (m *mockDockerController) ListContainers(ctx context.Context) ([]*docker.ContainerInfo, error) {
+	return nil, nil
+}
+
+func TestStartCourse_FileInjection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockDocker := &mockDockerController{}
+
+	memFS := fstest.MapFS{
+		"courses/mock-course/index.yaml": {Data: []byte(`
+title: Mock Course
+backend:
+  imageid: kwdb/kwdb
+  volumes:
+    - ./rdb.tar.gz:/kaiwudb/bin/rdb.tar.gz
+`)},
+		"courses/mock-course/rdb.tar.gz": {Data: []byte("mock-rdb-data")},
+	}
+
+	courseSvc := course.NewServiceFromFS(memFS, "courses")
+	courseSvc.LoadCourses()
+
+	cfg := &config.Config{
+		Course: config.CourseConfig{
+			DockerDeploy: true,
+			UseEmbed:     true,
+		},
+	}
+
+	loggerInstance := logger.NewLogger(logger.ERROR)
+	handler := &Handler{
+		courseService:         courseSvc,
+		dockerController:      mockDocker,
+		logger:                loggerInstance,
+		cfg:                   cfg,
+		courseStartInProgress: make(map[string]bool),
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest("POST", "/api/courses/mock-course/start", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: "mock-course"}}
+
+	handler.startCourse(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	files, ok := mockDocker.filesCopied["mock-container-id"]
+	if !ok {
+		t.Fatal("Expected files to be copied to container, but none were")
+	}
+
+	content, ok := files["/kaiwudb/bin/rdb.tar.gz"]
+	if !ok || string(content) != "mock-rdb-data" {
+		t.Errorf("Expected rdb.tar.gz to be injected with content 'mock-rdb-data', got %q", string(content))
 	}
 }

--- a/internal/api/handlers_course_runtime_test.go
+++ b/internal/api/handlers_course_runtime_test.go
@@ -37,10 +37,10 @@ func TestCourseStartInProgressGuard(t *testing.T) {
 
 func TestResolveStartCourseImage(t *testing.T) {
 	tests := []struct {
-		name		string
-		requestImage	string
-		backendImage	string
-		want		string
+		name         string
+		requestImage string
+		backendImage string
+		want         string
 	}{
 		{name: "prefer request image", requestImage: "a:b", backendImage: "x:y", want: "a:b"},
 		{name: "fallback backend image", requestImage: "", backendImage: "x:y", want: "x:y"},
@@ -59,9 +59,9 @@ func TestResolveStartCourseImage(t *testing.T) {
 
 func TestNormalizeCourseCmd(t *testing.T) {
 	tests := []struct {
-		name	string
-		in	[]string
-		want	[]string
+		name string
+		in   []string
+		want []string
 	}{
 		{name: "nil uses default", in: nil, want: []string{"/bin/bash", "-c", "while true; do sleep 3600; done"}},
 		{name: "single token unchanged", in: []string{"postgres"}, want: []string{"postgres"}},
@@ -182,9 +182,9 @@ type mockDockerController struct {
 
 func (m *mockDockerController) CreateContainerWithProgress(ctx context.Context, courseID string, config *docker.ContainerConfig, progressCallback docker.ImagePullProgressCallback) (*docker.ContainerInfo, error) {
 	return &docker.ContainerInfo{
-		ID:		"mock-container-id",
-		DockerID:	"mock-docker-id",
-		State:		docker.StateCreating,
+		ID:       "mock-container-id",
+		DockerID: "mock-docker-id",
+		State:    docker.StateCreating,
 	}, nil
 }
 
@@ -225,18 +225,18 @@ backend:
 
 	cfg := &config.Config{
 		Course: config.CourseConfig{
-			DockerDeploy:	true,
-			UseEmbed:	true,
+			DockerDeploy: true,
+			UseEmbed:     true,
 		},
 	}
 
 	loggerInstance := logger.NewLogger(logger.ERROR)
 	handler := &Handler{
-		courseService:		courseSvc,
-		dockerController:	mockDocker,
-		logger:			loggerInstance,
-		cfg:			cfg,
-		courseStartInProgress:	make(map[string]bool),
+		courseService:         courseSvc,
+		dockerController:      mockDocker,
+		logger:                loggerInstance,
+		cfg:                   cfg,
+		courseStartInProgress: make(map[string]bool),
 	}
 
 	w := httptest.NewRecorder()
@@ -262,4 +262,3 @@ backend:
 		t.Errorf("Expected rdb.tar.gz to be injected with content 'mock-rdb-data', got %q", string(content))
 	}
 }
-


### PR DESCRIPTION
## 摘要 (Summary)
修复了在使用 `UseEmbed=true` (如通过 `make release` 编译的二进制文件) 时，Docker 会因找不到宿主机对应路径而将 `rdb.tar.gz` 等文件错误创建为容器内同名空目录的问题。同时修复了由本次提交引入的 `go-lint` 格式化报错。

## 主要变更 (Key Changes)
- **API Handler (`internal/api/handlers_course_runtime.go`)**: 重构了容器卷挂载逻辑。现在只要挂载源路径以 `./` 开头（表明是课程自带文件），且当前处于 `UseEmbed=true` 或是 `DockerDeploy=true` 模式，就会优先通过 `courseService` 将文件读取为流，并使用 `CopyFilesToContainer` 直接注入到容器内，避免了触发 Docker Daemon 的 Bind Mount 机制。同时去除了多余的空行尾部空格。
- **测试 (`internal/api/handlers_course_runtime_test.go`)**: 
  - 新增了 `TestStartCourse_FileInjection` 单元测试，通过 Mock 的 Docker Controller 和基于 `fstest.MapFS` 虚拟的文件系统，验证了内嵌文件流注入逻辑的正确性。
  - **修复了 Go Lint 报错**：将结构体定义、实例化赋值等处的对齐空格全部替换为符合 `gofmt` 规范的制表符（Tab），解决了 GitHub Actions 中的代码格式化检查失败问题。

## 变更类型 (Type of Change)
- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 破坏性变更 (Breaking change)
- [x] 代码重构 (Refactor / Code cleanup)
- [ ] 文档更新 (Documentation update)

## 测试情况 (Testing Performed)
- 补充了专门的单元测试用例 `TestStartCourse_FileInjection`，覆盖文件被正确拦截并执行流注入的核心流程。
- 在本地验证了不使用真实物理目录直接启动二进制服务，相关压缩包文件能够以实际文件（非空目录）形式出现在容器指定目录中。
- 在本地成功执行 `gofmt -w` 及 `go test ./...`，确认所有格式符合 Go 官方规范。

close #223 
