### PR TITLE
feat: 启动课程时展示学习提示

### DIFF
--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -20,6 +20,7 @@ import {
   useLearnContainer,
   useLearnCourse,
   useLearnMarkdown,
+  pickRandomLearnStartTip,
 } from './learn/index'
 import { getCourseNotFoundError, getErrorInfo } from './learn/index'
 import { api } from '../lib/api/client'
@@ -48,6 +49,7 @@ export function Learn() {
   const [hostPortValue, setHostPortValue] = useState('')
   const [hostPortConflictMessage, setHostPortConflictMessage] = useState<string | null>(null)
   const [isHostPortChecking, setIsHostPortChecking] = useState(false)
+  const [startTip, setStartTip] = useState<string | null>(null)
 
   const sqlTerminalRef = useRef<SqlTerminalRef>(null)
   const terminalRef = useRef<TerminalRef>(null)
@@ -67,6 +69,7 @@ export function Learn() {
 
   useEffect(() => {
     const defaultPort = course?.backend?.port
+    setStartTip(null)
     if (typeof defaultPort === 'number' && defaultPort > 0) {
       setHostPortValue(String(defaultPort))
       setHostPortConflictMessage(null)
@@ -179,6 +182,7 @@ export function Learn() {
   const handleStartWithPort = useCallback(async () => {
     if (!course?.id) return
     if (!showHostPortSelector) {
+      setStartTip(pickRandomLearnStartTip())
       await startCourseContainer(course.id)
       return
     }
@@ -195,6 +199,7 @@ export function Learn() {
         return
       }
 
+      setStartTip(pickRandomLearnStartTip())
       await startCourseContainer(course.id, selectedPort)
     } catch (err) {
       setHostPortConflictMessage(err instanceof Error ? err.message : '端口检测失败，请稍后重试')
@@ -218,6 +223,7 @@ export function Learn() {
         title={course.title}
         containerStatus={containerStatus}
         isStartingContainer={isStartingContainer}
+        startTip={startTip}
         imageSourceLabel={imageSourceLabel}
         effectiveImage={effectiveImage}
         canPickImage={canPickImage}

--- a/src/pages/learn/components/LearnTopBar.test.tsx
+++ b/src/pages/learn/components/LearnTopBar.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { LearnTopBar } from './LearnTopBar'
+
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    toggleTheme: () => undefined,
+  }),
+}))
+
+const defaultProps = {
+  title: '快速开始',
+  containerStatus: 'stopped',
+  isStartingContainer: false,
+  imageSourceLabel: 'Docker Hub',
+  effectiveImage: 'kwdb/playground:latest',
+  canPickImage: true,
+  showHostPortSelector: false,
+  hostPortValue: '',
+  hostPortConflictMessage: null,
+  isHostPortChecking: false,
+  onHostPortChange: vi.fn(),
+  onBack: vi.fn(),
+  onOpenTour: vi.fn(),
+  onOpenImageSelector: vi.fn(),
+  onStart: vi.fn(),
+  onResume: vi.fn(),
+  onPause: vi.fn(),
+  onStop: vi.fn(),
+}
+
+const renderTopBar = (props?: Partial<typeof defaultProps & { startTip?: string | null }>) => {
+  return render(<LearnTopBar {...defaultProps} {...props} />)
+}
+
+describe('LearnTopBar', () => {
+  it('does not render start tip when no tip is provided', () => {
+    renderTopBar()
+
+    expect(screen.queryByTestId('learn-start-tip')).not.toBeInTheDocument()
+  })
+
+  it('renders start tip when provided', () => {
+    renderTopBar({ startTip: '启动前可以切换镜像源。' })
+
+    expect(screen.getByTestId('learn-start-tip')).toHaveTextContent('小提示')
+    expect(screen.getByTestId('learn-start-tip')).toHaveTextContent('启动前可以切换镜像源。')
+  })
+})

--- a/src/pages/learn/components/LearnTopBar.tsx
+++ b/src/pages/learn/components/LearnTopBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, HelpCircle, ImageIcon, Server } from 'lucide-react'
+import { ArrowLeft, HelpCircle, ImageIcon, Lightbulb, Server } from 'lucide-react'
 import StatusIndicator, { StatusType } from '../../../components/ui/StatusIndicator'
 import ThemeToggle from '../../../components/layout/ThemeToggle'
 import { useTheme } from '../../../hooks/useTheme'
@@ -7,6 +7,7 @@ type Props = {
   title: string
   containerStatus: string
   isStartingContainer: boolean
+  startTip?: string | null
   imageSourceLabel: string
   effectiveImage: string
   canPickImage: boolean
@@ -28,6 +29,7 @@ export const LearnTopBar = ({
   title,
   containerStatus,
   isStartingContainer,
+  startTip,
   imageSourceLabel,
   effectiveImage,
   canPickImage,
@@ -49,7 +51,7 @@ export const LearnTopBar = ({
 
   return (
     <header className="bg-[var(--color-bg-primary)] border-b border-[var(--color-border-light)] px-4 py-3 flex-shrink-0">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <div className="flex items-center space-x-2">
           <button onClick={onBack} className="btn btn-ghost text-sm" title="返回课程列表">
             <ArrowLeft className="h-4 w-4 mr-1.5" />
@@ -125,6 +127,20 @@ export const LearnTopBar = ({
           </div>
         </div>
       </div>
+      {startTip && (
+        <div
+          className="mt-2 flex items-start gap-2 rounded-md border border-[var(--color-accent-border)] bg-[var(--color-accent-subtle)] px-3 py-2 text-xs text-[var(--color-text-secondary)]"
+          role="status"
+          aria-live="polite"
+          data-testid="learn-start-tip"
+        >
+          <Lightbulb className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]" />
+          <div className="min-w-0 leading-5">
+            <span className="font-medium text-[var(--color-text-primary)]">小提示：</span>
+            <span>{startTip}</span>
+          </div>
+        </div>
+      )}
     </header>
   )
 }

--- a/src/pages/learn/index.ts
+++ b/src/pages/learn/index.ts
@@ -1,5 +1,6 @@
 export * from './constants'
 export * from './types'
+export * from './tips'
 export * from './components'
 export * from './hooks'
 export * from './markdown'

--- a/src/pages/learn/tips.test.ts
+++ b/src/pages/learn/tips.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { LEARN_START_TIPS, pickRandomLearnStartTip } from './tips'
+
+describe('learn start tips', () => {
+  it('returns the first tip when random is 0', () => {
+    expect(pickRandomLearnStartTip(() => 0)).toBe(LEARN_START_TIPS[0])
+  })
+
+  it('returns the last tip when random is close to 1', () => {
+    expect(pickRandomLearnStartTip(() => 0.999999)).toBe(LEARN_START_TIPS[LEARN_START_TIPS.length - 1])
+  })
+
+  it('contains non-empty tips', () => {
+    expect(LEARN_START_TIPS.length).toBeGreaterThan(0)
+    expect(LEARN_START_TIPS.every((tip) => tip.trim().length > 0)).toBe(true)
+  })
+})

--- a/src/pages/learn/tips.ts
+++ b/src/pages/learn/tips.ts
@@ -1,0 +1,19 @@
+export const LEARN_START_TIPS = [
+  '镜像下载较慢时，可以先切换到更近的镜像源再启动课程。',
+  '课程启动前会自动预检端口冲突，端口被占用时可以换一个主机端口。',
+  'Markdown 里的 Run 按钮会把命令发送到右侧终端，适合逐步验证课程步骤。',
+  'Shell 终端支持直接输入命令，也可以配合课程里的可执行代码块快速练习。',
+  'SQL 终端最后一行按 Enter 可执行，Shift+Enter 可以换行继续编辑。',
+  'Code 终端运行后会保留输出，方便你对比每次代码修改的结果。',
+  '暂时离开时可以暂停容器，下次恢复后继续使用当前学习环境。',
+  '遇到 Docker 或镜像源问题时，可以先打开环境检查查看诊断结果。',
+  'Shell 终端支持点击定位光标位置，方便快速修改命令参数。',
+] as const
+
+export const pickRandomLearnStartTip = (random = Math.random): string => {
+  const index = Math.min(
+    LEARN_START_TIPS.length - 1,
+    Math.floor(random() * LEARN_START_TIPS.length)
+  )
+  return LEARN_START_TIPS[index]
+}


### PR DESCRIPTION
## 摘要 (Summary)
启动课程容器时在学习页顶栏随机展示一条项目小提示，并在当前学习页会话中常驻，帮助用户发现镜像源、端口、终端和暂停恢复等常用能力。

## 主要变更 (Key Changes)
- **学习页状态**: 在课程启动前置校验通过后随机选择 tips，课程切换时清空，不持久化到本地存储。
- **顶栏展示**: 为 `LearnTopBar` 增加紧凑提示带，使用 `Lightbulb` 图标、`role="status"` 和 `aria-live="polite"`。
- **测试覆盖**: 新增 tips 随机选择边界测试和顶栏 tips 渲染测试。

## 变更类型 (Type of Change)
- [ ] Bug 修复 (Bug fix)
- [x] 新功能 (New feature)
- [ ] 破坏性变更 (Breaking change)
- [ ] 代码重构 (Refactor / Code cleanup)
- [ ] 文档更新 (Documentation update)

## 测试情况 (Testing Performed)
- `pnpm run check`
- `pnpm exec eslint src/pages/Learn.tsx src/pages/learn/components/LearnTopBar.tsx src/pages/learn/tips.ts src/pages/learn/tips.test.ts src/pages/learn/components/LearnTopBar.test.tsx`
- `git diff --check`

## 给 Reviewer 的提示 (Notes for Reviewers)
- 仅前端学习页改动，不涉及课程 YAML、后端接口或持久化存储。
