### PR TITLE
fix: 更新课程KWDB下载链接格式并修复install课程变量名

### DIFF
--- a/courses/install/step1.md
+++ b/courses/install/step1.md
@@ -18,16 +18,6 @@
 
     现在，我们官网下载最新的 KWDB 安装包。
 
-    首先，获取系统架构（`x86_64`、`aarch64` 均为官网支持的架构名）：
-
-    `ARCH=$(uname -m)`{{exec}}
-
-    然后，拼接下载链接：
-
-    `DOWNLOAD_URL="https://www.kaiwudb.com/api/download/direct-download/KWDB/v${KW_VERSION}/Linux/${ARCH}"`{{exec}}
-
-    最后，下载安装包：
-
-    `wget -O KWDB-${KW_VERSION}.run "${DOWNLOAD_URL}"`{{exec}}
+     `wget -O KWDB-${KW_VERSION}.run https://www.kaiwudb.com/api/download/direct-download/KWDB/v${KW_VERSION}/Linux/$(arch)`{{exec}}
 
 至此，准备工作已完成。在下一步中，我们将开始正式安装。

--- a/courses/install/step1.md
+++ b/courses/install/step1.md
@@ -18,6 +18,16 @@
 
     现在，我们官网下载最新的 KWDB 安装包。
 
-    `wget -O KWDB-${KW_VERSION}.run https://kwdb.tech/download/KWDB-${KW_VERSION}-$(arch)`{{exec}}
+    首先，获取系统架构（`x86_64`、`aarch64` 均为官网支持的架构名）：
+
+    `ARCH=$(uname -m)`{{exec}}
+
+    然后，拼接下载链接：
+
+    `DOWNLOAD_URL="https://www.kaiwudb.com/api/download/direct-download/KWDB/v${KW_VERSION}/Linux/${ARCH}"`{{exec}}
+
+    最后，下载安装包：
+
+    `wget -O KWDB-${KW_VERSION}.run "${DOWNLOAD_URL}"`{{exec}}
 
 至此，准备工作已完成。在下一步中，我们将开始正式安装。

--- a/courses/install/step2.md
+++ b/courses/install/step2.md
@@ -6,15 +6,15 @@
 
 1.  **赋予执行权限**
 
-    为了能够顺利执行部署脚本，我们需要为 `KWDB-${OLD_KW_VERSION}.run` 文件添加可执行权限。
+    为了能够顺利执行部署脚本，我们需要为 `KWDB-${KW_VERSION}.run` 文件添加可执行权限。
 
-    `chmod +x KWDB-${OLD_KW_VERSION}.run`{{exec}}
+    `chmod +x KWDB-${KW_VERSION}.run`{{exec}}
 
 2.  **启动向导程序**
 
     执行以下命令，以命令行模式启动向导程序：
 
-    `./KWDB-${OLD_KW_VERSION}.run -c`{{exec}}
+    `./KWDB-${KW_VERSION}.run -c`{{exec}}
 
 3.  **进入安装向导**
 

--- a/courses/upgrade/step1.md
+++ b/courses/upgrade/step1.md
@@ -10,7 +10,17 @@
 
 2. **下载并解压 3.2.0 安装包**
 
-   `wget -O KWDB-${OLD_KW_VERSION}.run https://kwdb.tech/download/KWDB-${OLD_KW_VERSION}-$(arch)`{{exec}}
+   获取系统架构（`x86_64`、`aarch64` 均为官网支持的架构名）：
+
+   `ARCH=$(uname -m)`{{exec}}
+
+   拼接下载链接：
+
+   `DOWNLOAD_URL="https://www.kaiwudb.com/api/download/direct-download/KWDB/v${OLD_KW_VERSION}/Linux/${ARCH}"`{{exec}}
+
+   下载安装包：
+
+   `wget -O KWDB-${OLD_KW_VERSION}.run "${DOWNLOAD_URL}"`{{exec}}
 
 3.  **赋予执行权限**
 

--- a/courses/upgrade/step1.md
+++ b/courses/upgrade/step1.md
@@ -10,17 +10,7 @@
 
 2. **下载并解压 3.2.0 安装包**
 
-   获取系统架构（`x86_64`、`aarch64` 均为官网支持的架构名）：
-
-   `ARCH=$(uname -m)`{{exec}}
-
-   拼接下载链接：
-
-   `DOWNLOAD_URL="https://www.kaiwudb.com/api/download/direct-download/KWDB/v${OLD_KW_VERSION}/Linux/${ARCH}"`{{exec}}
-
-   下载安装包：
-
-   `wget -O KWDB-${OLD_KW_VERSION}.run "${DOWNLOAD_URL}"`{{exec}}
+   `wget -O KWDB-${OLD_KW_VERSION}.run https://www.kaiwudb.com/api/download/direct-download/KWDB/v${OLD_KW_VERSION}/Linux/$(arch)`{{exec}}
 
 3.  **赋予执行权限**
 

--- a/courses/upgrade/step3.md
+++ b/courses/upgrade/step3.md
@@ -6,17 +6,7 @@
 
    `cd ~`{{exec}}
 
-   获取系统架构（`x86_64`、`aarch64` 均为官网支持的架构名）：
-
-   `ARCH=$(uname -m)`{{exec}}
-
-   拼接下载链接：
-
-   `DOWNLOAD_URL="https://www.kaiwudb.com/api/download/direct-download/KWDB/v${NEW_KW_VERSION}/Linux/${ARCH}"`{{exec}}
-
-   下载安装包：
-
-   `wget -O KWDB-${NEW_KW_VERSION}.run "${DOWNLOAD_URL}"`{{exec}}
+   `wget -O KWDB-${NEW_KW_VERSION}.run https://www.kaiwudb.com/api/download/direct-download/KWDB/v${NEW_KW_VERSION}/Linux/$(arch)`{{exec}}
 
 2.  **赋予执行权限**
 

--- a/courses/upgrade/step3.md
+++ b/courses/upgrade/step3.md
@@ -6,7 +6,17 @@
 
    `cd ~`{{exec}}
 
-   `wget -O KWDB-${NEW_KW_VERSION}.run https://kwdb.tech/download/KWDB-${NEW_KW_VERSION}-$(arch)`{{exec}}
+   获取系统架构（`x86_64`、`aarch64` 均为官网支持的架构名）：
+
+   `ARCH=$(uname -m)`{{exec}}
+
+   拼接下载链接：
+
+   `DOWNLOAD_URL="https://www.kaiwudb.com/api/download/direct-download/KWDB/v${NEW_KW_VERSION}/Linux/${ARCH}"`{{exec}}
+
+   下载安装包：
+
+   `wget -O KWDB-${NEW_KW_VERSION}.run "${DOWNLOAD_URL}"`{{exec}}
 
 2.  **赋予执行权限**
 


### PR DESCRIPTION
## 变更内容

### 1. 课程 KWDB 下载链接更新（install/upgrade 课程）

官方下载链接格式已更新为：

```
https://www.kaiwudb.com/api/download/direct-download/KWDB/v3.2.1/Linux/arm64
```

涉及的 3 个文件（install/step1.md、upgrade/step1.md、upgrade/step3.md）：

- **域名切换**：`kwdb.tech/download/` → `www.kaiwudb.com/api/download/direct-download/`
- **版本号**：增加 `v` 前缀（`v${KW_VERSION}`）
- **平台/架构**：新增 `Linux` 段，架构名映射为官网命名（`x86_64`→`amd64`，`aarch64`→`arm64`）
- **可读性**：将约 160 字符的长 wget 命令拆分为「获取架构 → 拼接链接 → 下载」三步，每步附带说明

`{{exec}}` 通过 `sendInput` 注入持久交互式 shell，变量（`ARCH`/`DOWNLOAD_URL`）可跨命令块保持，拆分不影响执行。

### 2. install 课程变量名修复（install/step2.md）

install 课程环境变量为 `KW_VERSION`，原文件误用 upgrade 课程的 `OLD_KW_VERSION`（在 install 容器中未定义），会导致 `chmod` 和安装程序执行失败。已修正。

## 验证

- 新链接格式与官方 API 一致（版本 `v` 前缀 + `Linux/<arch>` 路径段）
- 架构映射覆盖 x86_64 / aarch64 两种主流架构

## 备注

课程为构建期 embed，合并后需重新构建（`make release`）生效。